### PR TITLE
Render this repository obsolete and direct people to git.mean.io repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Dependencies Status](https://david-dm.org/linnovate/mean-admin.png)](https://david-dm.org/linnovate/mean-admin)
 
+# Annoucement
+
+This **package is now obsolete**. The new package which is actively being developed is at https://git.mean.io/linnovate/mean-admin.
+
+As new code is no longer being pushed on this repo, it is unlikely that issues will be tracked here effectively. So the new alternative should be used as soon as possible as issues will be acitvely tracked and fixed on git.mean.io for all mean-packages. 
+
 Admin module for MEAN applications to manage:
 
 - Modules list


### PR DESCRIPTION
Render this repository obsolete and direct people to git.mean.io repo for mean-admin
